### PR TITLE
fix: Return 401 JSON error for unauthenticated API requests

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -26,6 +26,11 @@ def create_app(config_object='src.config.DevelopmentConfig'):
     login_manager.login_message = "Please log in to access this page."
     login_manager.login_message_category = 'info'
 
+    @login_manager.unauthorized_handler
+    def unauthorized():
+        """Handle unauthorized requests for the API."""
+        return jsonify({'error': 'Authentication required'}), 401
+
     try:
         os.makedirs(app.instance_path)
     except OSError:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -70,10 +70,11 @@ class AuthTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 401)
 
     def test_access_protected_route_without_login(self):
-        """Test that a protected route cannot be accessed without logging in."""
+        """Test that a protected route returns 401 Unauthorized without login."""
         res = self.client.get('/api/summary')
-        self.assertEqual(res.status_code, 302) # Redirect to login page
-        self.assertIn('/api/auth/login', res.location)
+        self.assertEqual(res.status_code, 401)
+        data = json.loads(res.data)
+        self.assertEqual(data['error'], 'Authentication required')
 
     def test_access_protected_route_with_login(self):
         """Test that a protected route can be accessed after logging in."""
@@ -90,7 +91,9 @@ class AuthTestCase(unittest.TestCase):
         res_logout = self.client.post('/api/auth/logout')
         self.assertEqual(res_logout.status_code, 200)
         res_after_logout = self.client.get('/api/auth/profile')
-        self.assertEqual(res_after_logout.status_code, 302)
+        self.assertEqual(res_after_logout.status_code, 401)
+        data = json.loads(res_after_logout.data)
+        self.assertEqual(data['error'], 'Authentication required')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit fixes an issue where Flask-Login's default behavior would cause a 302 redirect for unauthenticated requests to protected API endpoints. This is not suitable for a RESTful API.

A custom `unauthorized_handler` has been added to the `LoginManager`. This handler now returns a proper 401 Unauthorized status code along with a `{'error': 'Authentication required'}` JSON response.

The corresponding backend tests have been updated to expect a 401 response instead of a 302 redirect.