### PR TITLE
fix: Correct login redirect and API unauthorized behavior

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -61,7 +61,6 @@ def register_main_routes(app):
     DATA_DIR = os.path.join(PROJECT_ROOT, 'data', 'invoices')
 
     @app.route('/')
-    @login_required
     def serve_dashboard():
         return send_from_directory(WEB_DIR, 'index.html')
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -22,5 +22,11 @@ class TestApi(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data, {"status": "ok"})
 
+    def test_root_is_public(self):
+        """Tests that the root URL ('/') is public and serves the main page."""
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<title>ComptaAI</title>', response.data)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit fixes the application's handling of unauthenticated users, creating distinct behavior for browser-based page loads and API requests.

- The root page ('/') is now public, allowing the frontend JavaScript to load and decide whether to show the login form or the dashboard. This resolves an issue where `Flask-Login` would cause an infinite redirect loop.
- The `unauthorized_handler` for API routes remains in place, correctly returning a 401 JSON error for any unauthenticated request to a protected API endpoint (e.g., `/api/summary`).
- Backend tests have been updated to reflect these changes.