### PR TITLE
feat: Prepare application for Flask-Migrate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask
 Flask-SQLAlchemy
 Flask-Login
 Flask-Bcrypt
+Flask-Migrate

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -6,7 +6,7 @@ from flask import Flask, jsonify, send_from_directory, make_response
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 # --- Local Imports ---
-from src.api.extensions import db, bcrypt, login_manager
+from src.api.extensions import db, bcrypt, login_manager, migrate
 from src.core.auth.models import User # Ensures user_loader is registered
 
 def create_app(config_object='src.config.DevelopmentConfig'):
@@ -22,6 +22,7 @@ def create_app(config_object='src.config.DevelopmentConfig'):
     db.init_app(app)
     bcrypt.init_app(app)
     login_manager.init_app(app)
+    migrate.init_app(app, db)
     login_manager.login_view = 'auth.login'
     login_manager.login_message = "Please log in to access this page."
     login_manager.login_message_category = 'info'

--- a/src/api/extensions.py
+++ b/src/api/extensions.py
@@ -5,7 +5,9 @@ They are instantiated here to avoid circular dependencies.
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
 bcrypt = Bcrypt()
 login_manager = LoginManager()
+migrate = Migrate()


### PR DESCRIPTION
This commit prepares the application for database schema management using Flask-Migrate.

- Adds `Flask-Migrate` to the project dependencies.
- Integrates the `Migrate` extension into the application factory.

The application is now ready for the `flask db` commands (`init`, `migrate`, `upgrade`) to be run to manage the schema.